### PR TITLE
Add endpoint tests and improve key handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore generated RSA keys
+keys/private.key
+keys/public.key
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -17,22 +17,40 @@ openssl genrsa -out keys/private.key 2048
 openssl rsa -in keys/private.key -pubout -out keys/public.key
 ```
 
+The repository includes a `keys/` directory with a placeholder file so it is
+created during deployment. Make sure to generate the key pair before running or
+deploying the app.
+
 3. Run the app:
 
 ```bash
 python app.py
 ```
 
+Visit `http://localhost:8080/launch` to initiate a sample Deep Linking session
+and open the picker interface.
+
 4. Expose with ngrok (optional for LMS testing):
 
 ```bash
-ngrok http 5000
+ngrok http 8080
+```
+
+Set `PORT` and `HOST` environment variables if deploying to a platform like Railway. By default the app runs on `0.0.0.0:8080`.
+
+### Testing
+
+Run the automated tests with:
+
+```bash
+pytest
 ```
 
 ## Endpoints
 
 - `/oidc/initiate`: Placeholder for OIDC login
 - `/lti/launch`: Accepts LTI launches, renders content picker
+- `/launch`: Generates a sample launch JWT and redirects to the picker
 - `/deep_link_picker`: Submits selected artefact to LMS
 - `/.well-known/jwks.json`: Publishes public key for LTI validation
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Launch LTI Deep Link</title>
+</head>
+<body onload="document.forms[0].submit()">
+    <h2>Launching LTI Deep Link...</h2>
+    <form action="/lti/launch" method="post">
+        <input type="hidden" name="id_token" value="{{ token }}">
+        <noscript>
+            <input type="submit" value="Continue">
+        </noscript>
+    </form>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,100 @@
+import importlib
+import time
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+import jwt
+import pytest
+import werkzeug
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "0"
+
+KID = "sample-key-id"
+
+@pytest.fixture(scope="session", autouse=True)
+def generate_keys(tmp_path_factory):
+    keys_dir = Path("keys")
+    keys_dir.mkdir(exist_ok=True)
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    (keys_dir / "private.key").write_bytes(priv_bytes)
+    (keys_dir / "public.key").write_bytes(pub_bytes)
+
+    yield
+
+@pytest.fixture()
+def client():
+    # Import app after keys exist
+    app = importlib.import_module("app").app
+    app.config.update({"TESTING": True})
+    with app.test_client() as client:
+        yield client
+
+def create_launch_jwt():
+    private_key = Path("keys/private.key").read_text()
+    payload = {
+        "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiDeepLinkingRequest",
+        "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+        "https://purl.imsglobal.org/spec/lti/claim/deep_linking_settings": {
+            "deep_link_return_url": "http://example.com/return"
+        },
+        "iss": "test",
+        "aud": "client",
+        "exp": int(time.time()) + 60,
+    }
+    return jwt.encode(payload, private_key, algorithm="RS256", headers={"kid": KID})
+
+def test_oidc_initiate(client):
+    resp = client.get("/oidc/initiate")
+    assert resp.status_code == 200
+    assert b"OIDC flow not fully implemented" in resp.data
+
+def test_launch_page(client):
+    resp = client.get("/launch")
+    assert resp.status_code == 200
+    assert b"Launch LTI Deep Link" in resp.data
+
+def test_launch_missing_token(client):
+    resp = client.post("/lti/launch")
+    assert resp.status_code == 400
+
+
+def test_launch_with_valid_token(client):
+    token = create_launch_jwt()
+    resp = client.post("/lti/launch", data={"id_token": token})
+    assert resp.status_code == 200
+    assert b"Deep Link Picker" in resp.data
+
+def test_deep_link_picker(client):
+    resp = client.post(
+        "/deep_link_picker",
+        data={
+            "deep_link_return_url": "http://example.com/return",
+            "content_url": "https://example.com/content/1",
+            "title": "Example",
+        },
+    )
+    assert resp.status_code == 200
+    assert b"Return to LMS" in resp.data
+
+def test_jwks(client):
+    resp = client.get("/.well-known/jwks.json")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "keys" in data and len(data["keys"]) == 1


### PR DESCRIPTION
## Summary
- add `.gitignore` ignoring RSA key files
- ensure `keys/` directory is tracked via `.gitkeep`
- check for key files at startup and allow host/port configuration
- document deployment notes and how to run tests
- add pytest-based endpoint tests which generate temporary RSA keys
- configure server for Railway default port 8080
- add `/launch` route and template to initiate a sample LTI session

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a134423b8832c97827fae5b71f32d