### PR TITLE
Update API token handling

### DIFF
--- a/lms-content-push/main.py
+++ b/lms-content-push/main.py
@@ -358,7 +358,7 @@ TEST_INTERFACE_HTML = """<!DOCTYPE html>
                     </div>
                     <div class="form-group">
                         <label for="apiToken">API Token</label>
-                        <input type="password" id="apiToken" value="dev-token-123" placeholder="Your API token">
+                        <input type="password" id="apiToken" placeholder="Your API token">
                     </div>
                 </div>
                 <button class="btn" onclick="testConnection()">Test Connection</button>
@@ -518,7 +518,9 @@ def get_db():
 
 # Simple auth check (replace with proper auth in production)
 async def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
-    expected_token = os.getenv("API_TOKEN", "dev-token-123")
+    expected_token = os.getenv("API_TOKEN")
+    if not expected_token:
+        raise RuntimeError("API_TOKEN environment variable not set")
     if credentials.credentials != expected_token:
         raise HTTPException(status_code=401, detail="Invalid authentication token")
     return credentials.credentials


### PR DESCRIPTION
## Summary
- remove default `dev-token-123` from test HTML
- require `API_TOKEN` env var in `verify_token`

## Testing
- `python -m py_compile lms-content-push/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688a88b41288832cad4d69a99929c065