### PR TITLE
Add FastAPI endpoint tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ keys/private.key
 keys/public.key
 __pycache__/
 .env
+lms_push.db

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,39 @@
+import os
+import importlib.util
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.fixture(scope="session")
+def app():
+    """Load the FastAPI app from main.py."""
+    os.environ.setdefault("API_TOKEN", "dev-token-123")
+    spec = importlib.util.spec_from_file_location(
+        "main", Path(__file__).resolve().parents[1] / "lms-content-push" / "main.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+@pytest.mark.asyncio
+async def test_health(app):
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        response = await client.get("/health")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("status") == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_destinations(app):
+    headers = {"Authorization": "Bearer dev-token-123"}
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        response = await client.get("/destinations", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert "main_lrs" in data
+    assert "analytics_webhook" in data
+


### PR DESCRIPTION
## Summary
- create tests for `/health` and `/destinations`
- ignore generated `lms_push.db` file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a88b8007c832cb47db6d7a8c678aa